### PR TITLE
Fix g:nerdtree_tabs_autofind=1 not working #94

### DIFF
--- a/nerdtree_plugin/vim-nerdtree-tabs.vim
+++ b/nerdtree_plugin/vim-nerdtree-tabs.vim
@@ -143,6 +143,10 @@ fun! s:NERDTreeOpenAllTabs()
   let l:current_tab = tabpagenr()
   tabdo call s:NERDTreeMirrorOrCreate()
   exe 'tabn ' . l:current_tab
+  if g:nerdtree_tabs_autofind
+    call s:NERDTreeUnfocus()
+    call s:NERDTreeFindFile()
+  endif
 endfun
 
 " }}}


### PR DESCRIPTION
It seems that g:nerdtree_tabs_autofind=1 is not working if NERDTree is opened manually by `:NERDTreeTabsToggle`